### PR TITLE
Move to CSV style output from pointing_jones

### DIFF
--- a/scripts/pointing_jones.py
+++ b/scripts/pointing_jones.py
@@ -21,8 +21,8 @@ from dreambeam.telescopes.rt import TelescopesWiz
 
 def printJonesFreq(timespy, Jnf):
     #Select one frequency
+    print ("Time, Freq, J11, J12, J21, J22")
     for ti in range(len(timespy)):
-        print ("Time, Freq, J11, J12, J21, J22")
         print (timespy[ti].isoformat(), freq, Jnf[ti,0,0], Jnf[ti,0,1], Jnf[ti,1,0], Jnf[ti,1,1])
         # Print out data for BST-mode comparison (ie powers of p & q channels):
         #print("{0} {1} {2}".format( (timespy[ti]-timespy[0]).total_seconds(), np.abs(Jnf[ti,0,0])**2+np.abs(Jnf[ti,0,1])**2, np.abs(Jnf[ti,1,0])**2+np.abs(Jnf[ti,1,1])**2) )


### PR DESCRIPTION
I had a quick look at including some very minor tweaks to make the output from pointing_jones consistent between 1-f and n-f modes and suitable for reading in any CSV reader/editor.  This should help us to use the output in later systems.