### PR TITLE
Include config files in the pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ setup(name='dreamBeam',
       packages=find_packages(),
       package_data={'dreambeam.telescopes.LOFAR':
                     ['share/*.cc', 'share/simmos/*.cfg',
-                     'share/alignment/*.txt', 'data/*teldat.p']},
+                     'share/alignment/*.txt', 'data/*teldat.p'],
+                    'dreambeam':
+                    ['configs/*.txt']},
+      include_package_data=True,
       license='ISC',
       classifiers=[
           'Development Status :: 1 - Planning',


### PR DESCRIPTION
Hey Tobia,

I was testting out dreamBeam and found the default install script wasn't copying the config files to the Python install path which was causing the sample scripts to exit early as a result. This is a quick PR to fix that for you.

Cheers