### PR TITLE
Convert Station Names from Bytes to Strings to prevent several errors

### DIFF
--- a/dreambeam/telescopes/rt.py
+++ b/dreambeam/telescopes/rt.py
@@ -64,6 +64,8 @@ class TelescopePlugin(object):
             self.stations[band] = stnids.tolist()
             self.positions[band] = zip(xs.tolist(), ys.tolist(), zs.tolist())
             self.diams[band] = diams.tolist()
+            if type(self.stations[band][0]) is bytes:
+                self.stations[band] = [val.decode('ascii') for val in self.stations[band]]
         self.bandstnrot = {}
         for band in self.bands:
             self.bandstnrot[band] = {}


### PR DESCRIPTION
Hey Tobia, 

Ran into another issue while testing out the sample scripts which is likely a side effect of the python2/3 transition, the values for station names seem to be stored as bytes, which when automatically converted to strings in python 3 get wrapped with b'', this is a quick patch that will convert these bytes to strings to prevent several errors such as file not found from the extra characters and missing function errors as '<val>'.join(variable) can no longer be called on bytestrings.

Cheers 