### PR TITLE
More Python 2/3 Conversion Fixes

### DIFF
--- a/dreambeam/feeds/feedplugins.py
+++ b/dreambeam/feeds/feedplugins.py
@@ -191,7 +191,7 @@ class FeedPlugin(object):
         return dpes
 
     def load_dpolel(self, band, modelstring):
-        modeltype, version = modelstring.split(self._mdlversep, 1)
+        modeltype, version, *_ = modelstring.split(self._mdlversep, 1) + [None, None]
         if version is None:
             versions = self.list_versions4bandmodels(band, modeltype)
             version = versions[0]

--- a/dreambeam/feeds/feedplugins.py
+++ b/dreambeam/feeds/feedplugins.py
@@ -191,7 +191,12 @@ class FeedPlugin(object):
         return dpes
 
     def load_dpolel(self, band, modelstring):
-        modeltype, version, *_ = modelstring.split(self._mdlversep, 1) + [None, None]
+        if self._mdlversep in modelstring:
+            modeltype, version = modelstring.split(self._mdlversep, 1)
+        else:
+            modeltype = modelstring
+            version = None
+        #modeltype, version, *_ = modelstring.split(self._mdlversep, 1) + [None, None]
         if version is None:
             versions = self.list_versions4bandmodels(band, modeltype)
             version = versions[0]

--- a/dreambeam/telescopes/rt.py
+++ b/dreambeam/telescopes/rt.py
@@ -61,11 +61,9 @@ class TelescopePlugin(object):
         self.diams = {}
         for band in self.bands:
             xs, ys, zs, diams, stnids = gi.readarrcfg(self.name, band)
-            self.stations[band] = stnids.tolist()
-            self.positions[band] = zip(xs.tolist(), ys.tolist(), zs.tolist())
+            self.stations[band] = stnids.astype(str).tolist()
+            self.positions[band] = list(zip(xs.tolist(), ys.tolist(), zs.tolist()))
             self.diams[band] = diams.tolist()
-            if type(self.stations[band][0]) is bytes:
-                self.stations[band] = [val.decode('ascii') for val in self.stations[band]]
         self.bandstnrot = {}
         for band in self.bands:
             self.bandstnrot[band] = {}


### PR DESCRIPTION
Hey Tobia, here's another issue from the python 2/3 conversion fixed and a better fix put in place from the one I gave you in rt.py yesterday. Cheers

feedplugins.py:
I'm guessing that previously the array would be padded with a None if only 1 value was returned, this is a bit hack-y, but work.

rt.py:
Better fix compared to yesterday, convert the numpy array type rather than the resulting values.
Convert the positions zip to a list as zips are enumerators in python 3 and cannot be indexed