### PR TITLE
setup.py:  Copy NenuFAR configurations on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(name='dreamBeam',
       package_data={'dreambeam.telescopes.LOFAR':
                     ['share/*.cc', 'share/simmos/*.cfg',
                      'share/alignment/*.txt'],
+                    'dreambeam.telescopes.NenuFAR':
+                    ['share/*.cc', 'share/simmos/*.cfg',
+                     'share/alignment/*.txt'],
                     'dreambeam':
                     ['configs/*.txt']},
       include_package_data=True,


### PR DESCRIPTION
Hey Tobia,

Another quick PR for you. I was installing dreamBeam on our compute nodes and I was running into an error when trying to use `on_pointing_axis_tracking`. Even though I was using a LOFAR station, I was getting an error about NenuFAR files being missing:

```  File "/usr/local/lib/python3.6/dist-packages/dreambeam/rime/scenarios.py", line 113, in on_pointing_axis_tracking
    stnfeed = load_mountedfeed(telescopename, stnid, band, antmodel)
  File "/usr/local/lib/python3.6/dist-packages/dreambeam/telescopes/rt.py", line 42, in load_mountedfeed
    telescope_plugins = get_tel_plugins()
  File "/usr/local/lib/python3.6/dist-packages/dreambeam/telescopes/rt.py", line 31, in get_tel_plugins
    pluginpath)
  File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.6/dist-packages/dreambeam/telescopes/NenuFAR/_telescope.py", line 15, in <module>
    telhelper = TelescopePlugin(TELESCOPE_NAME, MountedFeedFixed, POLCRDROT)
  File "/usr/local/lib/python3.6/dist-packages/dreambeam/telescopes/rt.py", line 57, in __init__
    self.bands = self.feedplugin.get_bands()
  File "/usr/local/lib/python3.6/dist-packages/dreambeam/feeds/feedplugins.py", line 140, in get_bands
    coeffilemetas = self._search_coeff_files()
  File "/usr/local/lib/python3.6/dist-packages/dreambeam/feeds/feedplugins.py", line 129, in _search_coeff_files
    ls = os.listdir(modelspecdir)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.6/dist-packages/dreambeam/telescopes/NenuFAR/share'
```

I checked out setup.py and it looks like the only the LOFAR configuration files were being copied, this PR just adds in the NenuFAR files as well and resolves the issue I was having above.

Cheers,
David