### PR TITLE
Use full integration time when calculating nrTimSamps in on_pointing_axis_tracking

### DIFF
--- a/dreambeam/rime/scenarios.py
+++ b/dreambeam/rime/scenarios.py
@@ -115,7 +115,7 @@ def on_pointing_axis_tracking(telescopename, stnid, band, antmodel, obstimebeg,
 
     #    *Setup PJones*
     timespy = []
-    nrTimSamps = int((obsdur.total_seconds()/obstimestp.seconds))+1
+    nrTimSamps = int((obsdur.total_seconds()/obstimestp.total_seconds()))+1
     for ti in range(0, nrTimSamps):
         timespy.append(obstimebeg+ti*obstimestp)
     pjones = dreambeam.rime.jones.PJones(timespy, np.transpose(stnrot),


### PR DESCRIPTION
Hey Tobia,

Not sure if this was intentional or not, but I found that on_pointing_axis_tracking was not returning the amount of time steps I expected, and ended up tracking it down to a TimeDelta division where only the number of seconds were being used to determine the time step, discarding fractions of seconds (div by 0 error for < 1 second), or minutes/hours/etc (producing far too many time steps as a result). 

This is a quick PR that fixes that issue, and changes the TimeDelta.seconds variable to TimeDelta.total_seconds() for increased accuracy when determiningthe number of requested time samples.

Cheers,
David